### PR TITLE
Fix gaps in vertical box-drawing glyphs

### DIFF
--- a/Nvmm/Render/ShaderTypes.h
+++ b/Nvmm/Render/ShaderTypes.h
@@ -82,8 +82,8 @@ typedef struct {
 /// `glyph_data.flags`: this glyph is the block cursor's x-ray character.
 #define GLYPH_FLAG_XRAY 1u
 
-/// One procedurally-drawn cell graphic (block/shade/diagonal fills) that the
-/// fragment shader renders without a glyph texture.
+/// One procedurally-drawn cell graphic (block, shade, diagonal, or separator)
+/// that the fragment shader renders without a glyph texture.
 typedef struct {
     simd_short2 grid_position;
     uint32_t cell_width;

--- a/Nvmm/Render/Shaders.metal
+++ b/Nvmm/Render/Shaders.metal
@@ -414,6 +414,9 @@ fragment float4 cell_graphic_fill(cell_graphic_rasterizer_data in [[stage_in]]) 
     constexpr uint32_t light_shade = 4;
     constexpr uint32_t diagonal_upper_right_to_lower_left = 5;
     constexpr uint32_t diagonal_upper_left_to_lower_right = 6;
+    constexpr uint32_t light_vertical = 7;
+    constexpr uint32_t heavy_vertical = 8;
+    constexpr uint32_t double_vertical = 9;
 
     if (in.kind == full_block) {
         return float4(in.color.rgb, 1.0);
@@ -438,6 +441,29 @@ fragment float4 cell_graphic_fill(cell_graphic_rasterizer_data in [[stage_in]]) 
     float2 local = in.position.xy - in.cell_position;
     float width = in.cell_size.x;
     float height = in.cell_size.y;
+
+    if (in.kind == light_vertical ||
+        in.kind == heavy_vertical ||
+        in.kind == double_vertical) {
+        float light_half_width = max(0.65, min(width, height) * 0.045);
+        float dist;
+
+        if (in.kind == double_vertical) {
+            float offset = max(light_half_width * 2.25, width * 0.18);
+            dist = min(abs(local.x - (width * 0.5 - offset)),
+                       abs(local.x - (width * 0.5 + offset)));
+        } else {
+            dist = abs(local.x - width * 0.5);
+        }
+
+        float half_width = in.kind == heavy_vertical
+            ? light_half_width * 2.0 : light_half_width;
+        float alpha = 1.0 - smoothstep(half_width,
+                                       half_width + 0.85, dist);
+        if (alpha <= 0.0) discard_fragment();
+        return float4(in.color.rgb, alpha);
+    }
+
     float diagonal_length = length(in.cell_size);
     float dist = 0.0;
 

--- a/Nvmm/Window/GridView.swift
+++ b/Nvmm/Window/GridView.swift
@@ -41,6 +41,9 @@ private enum CellGraphicKind: UInt32 {
     case lightShade = 4
     case diagonalUpperRightToLowerLeft = 5
     case diagonalUpperLeftToLowerRight = 6
+    case lightVertical = 7
+    case heavyVertical = 8
+    case doubleVertical = 9
 
     /// The kind a grapheme maps to, or nil if it is not a cell graphic.
     init?(grapheme: String) {
@@ -51,6 +54,10 @@ private enum CellGraphicKind: UInt32 {
         case "\u{2591}": self = .lightShade       // ░
         case "\u{2571}": self = .diagonalUpperRightToLowerLeft // ╱
         case "\u{2572}": self = .diagonalUpperLeftToLowerRight // ╲
+        // Render vertical box-drawing glyphs at full cell height so adjacent rows join.
+        case "\u{2502}": self = .lightVertical // │
+        case "\u{2503}": self = .heavyVertical // ┃
+        case "\u{2551}": self = .doubleVertical // ║
         default: return nil
         }
     }

--- a/Tests/RenderTests.swift
+++ b/Tests/RenderTests.swift
@@ -73,6 +73,80 @@ final class RenderTests: XCTestCase {
         XCTAssertGreaterThan(family.width, 0)
     }
 
+    func testCellGraphicShaderJoinsVerticalSeparatorAcrossRows() throws {
+        try requireDevice()
+        let context = try RenderContextManager().defaultRenderContext()
+        let device = context.device
+        let cellWidth = 12
+        let cellHeight = 18
+        let outputWidth = cellWidth
+        let outputHeight = cellHeight * 2
+
+        var uniforms = uniform_data(
+            pixel_size: SIMD2<Float>(2.0 / Float(outputWidth),
+                                     -2.0 / Float(outputHeight)),
+            cell_pixel_size: SIMD2<Float>(Float(cellWidth), Float(cellHeight)),
+            baseline: .zero, cursor_position: .zero, cursor_color: 0,
+            cursor_line_width: 0, cursor_cell_width: 1, grid_width: 1,
+            cursor_xray: 0)
+        let uniformBuffer = try XCTUnwrap(withUnsafeBytes(of: &uniforms) {
+            device.makeBuffer(bytes: $0.baseAddress!, length: $0.count)
+        })
+
+        // `CellGraphicKind.lightVertical` is private host-side state; 7 is its
+        // wire value consumed by the shader.
+        let lightVertical: UInt32 = 7
+        let graphics = [0, 1].map { row in
+            cell_graphic_data(
+                grid_position: SIMD2<Int16>(0, Int16(row)), cell_width: 1,
+                color: UInt32.max, background_color: 0,
+                kind: lightVertical)
+        }
+        let graphicBuffer = try XCTUnwrap(graphics.withUnsafeBytes {
+            device.makeBuffer(bytes: $0.baseAddress!, length: $0.count)
+        })
+
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm, width: outputWidth,
+            height: outputHeight, mipmapped: false)
+        descriptor.usage = [.renderTarget]
+        descriptor.storageMode = .shared
+        let output = try XCTUnwrap(device.makeTexture(descriptor: descriptor))
+        let pass = MTLRenderPassDescriptor()
+        pass.colorAttachments[0].texture = output
+        pass.colorAttachments[0].loadAction = .clear
+        pass.colorAttachments[0].storeAction = .store
+        pass.colorAttachments[0].clearColor = MTLClearColorMake(0, 0, 0, 0)
+
+        let command = try XCTUnwrap(context.commandQueue.makeCommandBuffer())
+        let encoder = try XCTUnwrap(command.makeRenderCommandEncoder(
+            descriptor: pass))
+        encoder.setRenderPipelineState(context.cellGraphicPipeline)
+        encoder.setVertexBuffer(uniformBuffer, offset: 0, index: 0)
+        encoder.setVertexBuffer(graphicBuffer, offset: 0, index: 1)
+        encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0,
+                               vertexCount: 4, instanceCount: graphics.count)
+        encoder.endEncoding()
+        command.commit()
+        command.waitUntilCompleted()
+        XCTAssertEqual(command.status, .completed)
+
+        var pixels = [UInt8](repeating: 0,
+                             count: outputWidth * outputHeight * 4)
+        output.getBytes(&pixels, bytesPerRow: outputWidth * 4,
+                        from: MTLRegionMake2D(0, 0, outputWidth, outputHeight),
+                        mipmapLevel: 0)
+        func alpha(_ x: Int, _ y: Int) -> UInt8 {
+            pixels[(y * outputWidth + x) * 4 + 3]
+        }
+
+        let center = cellWidth / 2
+        XCTAssertGreaterThan(alpha(center, cellHeight - 1), 0)
+        XCTAssertGreaterThan(alpha(center, cellHeight), 0)
+        XCTAssertEqual(alpha(0, cellHeight - 1), 0)
+        XCTAssertEqual(alpha(0, cellHeight), 0)
+    }
+
     func testFrameBufferRetriesAfterAllocationFailure() throws {
         try requireDevice()
         let device = try XCTUnwrap(MTLCreateSystemDefaultDevice())


### PR DESCRIPTION
## Summary

Render the light, heavy, and double vertical box-drawing characters through
Nvmm's existing procedural cell-graphics pipeline:

- `│` light vertical
- `┃` heavy vertical
- `║` double vertical

This keeps vertical separators continuous across adjacent grid rows instead of
depending on each font's glyph metrics.

## Motivation

Some fonts leave vertical padding around box-drawing glyphs, causing separators
to appear dotted or broken between rows. I originally encountered this with
Triplicate T4 Code (proprietary). It is also reproducible with the freely
available Iosevka Nerd Font Mono, particularly when using a nonzero
`linespace`.

This approach follows the same general idea as Neovide's native box-drawing
renderer, which handles these characters independently of the selected font:

https://github.com/neovide/neovide/pull/3033

## Screenshots

### Before
<img width="521" height="360" alt="ScreenFloat Shot of Nvmm on 2026-08-23 at 14-54-59" src="https://github.com/user-attachments/assets/35d94883-d0e4-4bb3-ba81-4375d84d9ff9" />

### After

<img width="561" height="384" alt="ScreenFloat Shot of Nvmm on 2026-08-23 at 14-55-42" src="https://github.com/user-attachments/assets/dbda12b7-e974-4ddf-b833-cdccc0d39140" />


## Testing

- Added an offscreen Metal regression test that renders separators across two
  rows and checks both sides of the row boundary.
- Visually verified the fix with Triplicate T4 Code.
- Visually verified the reproduction and fix with Iosevka Nerd Font Mono and
  `linespace=16`.
- Verified the renderer regression test passes.
