### PR TITLE
Support explicit fallback fonts in guifont

### DIFF
--- a/Nvmm/Render/FontManager.swift
+++ b/Nvmm/Render/FontManager.swift
@@ -14,6 +14,12 @@
 import AppKit
 import CoreText
 
+/// One configured font at its user-facing, unscaled point size.
+struct ResolvedGuifontEntry {
+    let descriptor: CTFontDescriptor
+    let unscaledSize: CGFloat
+}
+
 /// The four faces of one typeface at a fixed size, plus layout metrics.
 struct FontFamily {
     /// Faces indexed by `FontAttributes` raw order: none, bold, italic,
@@ -21,20 +27,25 @@ struct FontFamily {
     private var fonts: [CTFont]
     private var wideFonts: [CTFont]?
 
-    /// The size before applying `scaleFactor`, in points.
-    let unscaledSize: CGFloat
-    fileprivate let wideUnscaledSize: CGFloat?
+    /// The ordered source descriptors and sizes used to build this family.
+    /// The first entry is primary; later entries are explicit fallbacks.
+    fileprivate let resolvedEntries: [ResolvedGuifontEntry]
+    fileprivate let wideEntry: ResolvedGuifontEntry?
+
+    /// The primary size before applying `scaleFactor`, in points.
+    var unscaledSize: CGFloat { resolvedEntries[0].unscaledSize }
 
     /// The backing-scale multiplier applied to `unscaledSize`.
     let scaleFactor: CGFloat
 
     fileprivate init(fonts: [CTFont], wideFonts: [CTFont]?,
-                     unscaledSize: CGFloat, wideUnscaledSize: CGFloat?,
+                     resolvedEntries: [ResolvedGuifontEntry],
+                     wideEntry: ResolvedGuifontEntry?,
                      scaleFactor: CGFloat) {
         self.fonts = fonts
         self.wideFonts = wideFonts
-        self.unscaledSize = unscaledSize
-        self.wideUnscaledSize = wideUnscaledSize
+        self.resolvedEntries = resolvedEntries
+        self.wideEntry = wideEntry
         self.scaleFactor = scaleFactor
     }
 
@@ -90,7 +101,7 @@ final class FontManager {
 
     private struct Entry {
         let font: CTFont
-        let name: String
+        let descriptor: CTFontDescriptor
         let size: CGFloat
     }
 
@@ -117,11 +128,22 @@ final class FontManager {
         return CTFontDescriptorCreateMatchingFontDescriptor(descriptor, nil)
     }
 
-    private func font(for descriptor: CTFontDescriptor, size: CGFloat) -> CTFont {
-        let name = (CTFontDescriptorCopyAttribute(descriptor, kCTFontNameAttribute)
-            as? String) ?? ""
+    /// Resolves installed entries while preserving their configured order.
+    static func makeResolvedGuifontEntries(
+        _ entries: [GuifontEntry]
+    ) -> [ResolvedGuifontEntry] {
+        entries.compactMap { entry -> ResolvedGuifontEntry? in
+            guard let descriptor = makeDescriptor(entry.name) else {
+                return nil
+            }
+            return ResolvedGuifontEntry(
+                descriptor: descriptor, unscaledSize: entry.size)
+        }
+    }
 
-        for entry in usedFonts where entry.size == size && entry.name == name {
+    private func font(for descriptor: CTFontDescriptor, size: CGFloat) -> CTFont {
+        for entry in usedFonts where entry.size == size
+            && CFEqual(entry.descriptor, descriptor) {
             return entry.font
         }
 
@@ -130,7 +152,8 @@ final class FontManager {
         if usedFonts.count >= Self.maximumCachedFonts {
             usedFonts.removeFirst()
         }
-        usedFonts.append(Entry(font: font, name: name, size: size))
+        usedFonts.append(Entry(
+            font: font, descriptor: descriptor, size: size))
         return font
     }
 
@@ -139,46 +162,79 @@ final class FontManager {
                 scaleFactor: CGFloat,
                 wideDescriptor: CTFontDescriptor? = nil,
                 wideSize: CGFloat? = nil) -> FontFamily {
-        let fonts = faces(for: descriptor, size: size * scaleFactor)
-        let resolvedWideSize = wideDescriptor.map { _ in wideSize ?? size }
+        let primary = ResolvedGuifontEntry(
+            descriptor: descriptor, unscaledSize: size)
+        let wideEntry = wideDescriptor.map {
+            ResolvedGuifontEntry(
+                descriptor: $0, unscaledSize: wideSize ?? size)
+        }
+        return family(resolvedEntries: [primary], scaleFactor: scaleFactor,
+                      wideEntry: wideEntry)
+    }
+
+    /// A family built from a nonempty ordered list: primary, then fallbacks.
+    func family(resolvedEntries: [ResolvedGuifontEntry], scaleFactor: CGFloat,
+                wideEntry: ResolvedGuifontEntry? = nil) -> FontFamily {
+        precondition(!resolvedEntries.isEmpty)
+        let primary = resolvedEntries[0]
+        let fonts = faces(
+            for: primary.descriptor,
+            size: primary.unscaledSize * scaleFactor,
+            fallbacks: Array(resolvedEntries.dropFirst()),
+            scaleFactor: scaleFactor)
         let wideFonts: [CTFont]?
-        if let wideDescriptor, let resolvedWideSize {
+        if let wideEntry {
             wideFonts = faces(
-                for: wideDescriptor, size: resolvedWideSize * scaleFactor)
+                for: wideEntry.descriptor,
+                size: wideEntry.unscaledSize * scaleFactor)
         } else {
             wideFonts = nil
         }
         return FontFamily(fonts: fonts, wideFonts: wideFonts,
-                          unscaledSize: size,
-                          wideUnscaledSize: resolvedWideSize,
+                          resolvedEntries: resolvedEntries,
+                          wideEntry: wideEntry,
                           scaleFactor: scaleFactor)
+    }
+
+    /// A copy of `family` with a new wide-font entry, reusing its existing
+    /// primary and fallback descriptors unchanged.
+    ///
+    /// This still rebuilds the cascaded descriptor and goes through
+    /// `font(for:size:)`; the non-wide faces come back identical only
+    /// because that cache matches on `CFEqual(descriptor)` + size, not
+    /// because construction is skipped. If the cache key ever changes,
+    /// this stops being a no-op for those faces.
+    func family(reusing family: FontFamily, wideEntry: ResolvedGuifontEntry?,
+                scaleFactor: CGFloat) -> FontFamily {
+        self.family(resolvedEntries: family.resolvedEntries,
+                    scaleFactor: scaleFactor, wideEntry: wideEntry)
     }
 
     /// A copy of `family` at a new unscaled size, otherwise equivalent.
     func resized(_ family: FontFamily, size: CGFloat,
                  scaleFactor: CGFloat) -> FontFamily {
-        let faces: [FontAttributes] = [.none, .bold, .italic, .boldItalic]
-        let fonts = faces.map {
-            font(for: CTFontCopyFontDescriptor(family.font($0)),
-                 size: size * scaleFactor)
+        let delta = size - family.unscaledSize
+        let resolvedEntries = family.resolvedEntries.map {
+            ResolvedGuifontEntry(
+                descriptor: $0.descriptor,
+                unscaledSize: max(1, $0.unscaledSize + delta))
         }
-        let wideSize = family.wideUnscaledSize.map {
-            max(1, $0 + size - family.unscaledSize)
+        let wideEntry = family.wideEntry.map {
+            ResolvedGuifontEntry(
+                descriptor: $0.descriptor,
+                unscaledSize: max(1, $0.unscaledSize + delta))
         }
-        let wideFonts = wideSize.map { wideSize in
-            faces.map {
-                font(for: CTFontCopyFontDescriptor(
-                    family.font($0, wide: true)),
-                     size: wideSize * scaleFactor)
-            }
-        }
-        return FontFamily(fonts: fonts, wideFonts: wideFonts,
-                          unscaledSize: size, wideUnscaledSize: wideSize,
-                          scaleFactor: scaleFactor)
+        return self.family(
+            resolvedEntries: resolvedEntries,
+            scaleFactor: scaleFactor, wideEntry: wideEntry)
     }
 
     private func faces(for descriptor: CTFontDescriptor,
-                       size: CGFloat) -> [CTFont] {
+                       size: CGFloat,
+                       fallbacks: [ResolvedGuifontEntry] = [],
+                       scaleFactor: CGFloat = 1) -> [CTFont] {
+        let descriptor = cascadedDescriptor(
+            descriptor, fallbacks: fallbacks, scaleFactor: scaleFactor)
         let mask: CTFontSymbolicTraits = [.traitBold, .traitItalic]
         let boldDescriptor = CTFontDescriptorCreateCopyWithSymbolicTraits(
             descriptor, .traitBold, mask)
@@ -193,5 +249,32 @@ final class FontManager {
             font(for: $0, size: size)
         } ?? regular
         return [regular, bold, italic, boldItalic]
+    }
+
+    /// Attaches an ordered CoreText cascade to `descriptor`.
+    ///
+    /// Each fallback's own size attribute is set here for completeness, but
+    /// CoreText does not honor it when substituting a glyph: a face picked
+    /// from the cascade list is always sized to match the primary face,
+    /// not its own configured size. Fallback fonts only ever contribute a
+    /// choice of typeface, never an independent size.
+    private func cascadedDescriptor(
+        _ descriptor: CTFontDescriptor,
+        fallbacks: [ResolvedGuifontEntry],
+        scaleFactor: CGFloat
+    ) -> CTFontDescriptor {
+        guard !fallbacks.isEmpty else { return descriptor }
+        let cascade = fallbacks.map { fallback in
+            let attributes = [
+                kCTFontSizeAttribute as String:
+                    fallback.unscaledSize * scaleFactor,
+            ] as CFDictionary
+            return CTFontDescriptorCreateCopyWithAttributes(
+                fallback.descriptor, attributes)
+        }
+        let attributes = [
+            kCTFontCascadeListAttribute as String: cascade,
+        ] as CFDictionary
+        return CTFontDescriptorCreateCopyWithAttributes(descriptor, attributes)
     }
 }

--- a/Nvmm/Render/Guifont.swift
+++ b/Nvmm/Render/Guifont.swift
@@ -6,8 +6,8 @@
 //
 //  `guifont` is a comma-separated list of fonts, each optionally suffixed with
 //  `:h<size>` (a point size). Commas inside a font name are backslash-escaped.
-//  The list is tried in order; the window uses the first face installed on the
-//  system. This is pure value logic with no AppKit dependency.
+//  Installed entries retain their order as primary and fallback fonts. This is
+//  pure value logic with no AppKit dependency.
 //
 
 import CoreGraphics

--- a/Nvmm/Window/WindowController.swift
+++ b/Nvmm/Window/WindowController.swift
@@ -1435,19 +1435,22 @@ final class WindowController: NSWindowController, NSWindowDelegate,
         }
         guard let screen = window?.screen ?? NSScreen.main else { return }
 
-        let descriptor: CTFontDescriptor
-        let size: CGFloat
+        let font: FontFamily
         if !primaryChanged, let current = gridView.fontFamily {
-            descriptor = CTFontCopyFontDescriptor(current.regular)
-            size = current.unscaledSize
+            let wideEntry = resolveWideFont(
+                guifontwide, defaultSize: current.unscaledSize)
+            font = renderManager.fontManager.family(
+                reusing: current, wideEntry: wideEntry,
+                scaleFactor: screen.backingScaleFactor)
         } else {
-            (descriptor, size) = resolveFont(resolvedGuifont)
+            let resolvedEntries = resolveFont(resolvedGuifont)
+            let wideEntry = resolveWideFont(
+                guifontwide, defaultSize: resolvedEntries[0].unscaledSize)
+            font = renderManager.fontManager.family(
+                resolvedEntries: resolvedEntries,
+                scaleFactor: screen.backingScaleFactor,
+                wideEntry: wideEntry)
         }
-        let wide = resolveWideFont(guifontwide, defaultSize: size)
-        let font = renderManager.fontManager.family(
-            descriptor: descriptor, size: size,
-            scaleFactor: screen.backingScaleFactor,
-            wideDescriptor: wide?.0, wideSize: wide?.1)
         setFont(font)
         if window?.isMainWindow == true {
             updateFontManagerSelection()
@@ -1505,34 +1508,29 @@ final class WindowController: NSWindowController, NSWindowDelegate,
         [.collection, .face, .size]
     }
 
-    /// Resolves a `guifont` list to a descriptor and size: the first installed
-    /// face wins. When the list is non-empty but none of its fonts exist, the
-    /// error is reported to Neovim and the default monospaced font is used at
-    /// the default size. An empty list quietly uses the default.
-    private func resolveFont(_ guifont: String) -> (CTFontDescriptor, CGFloat) {
+    /// Resolves `guifont` to an ordered list: primary, then fallbacks.
+    /// Missing entries are skipped. When none are installed, a non-empty list
+    /// reports an error and the default monospaced font is used instead.
+    private func resolveFont(_ guifont: String) -> [ResolvedGuifontEntry] {
         let fonts = parseGuifont(guifont, defaultSize: defaultFontSize)
-        for entry in fonts {
-            if let descriptor = FontManager.makeDescriptor(entry.name) {
-                return (descriptor, entry.size)
-            }
-        }
+        let installed = FontManager.makeResolvedGuifontEntries(fonts)
+        if !installed.isEmpty { return installed }
         if !fonts.isEmpty {
             enqueue(.errorWriteln("Error: Invalid font(s): guifont=\(guifont)"))
         }
-        return (FontManager.defaultDescriptor(), defaultFontSize)
+        return [ResolvedGuifontEntry(
+            descriptor: FontManager.defaultDescriptor(),
+            unscaledSize: defaultFontSize)]
     }
 
     /// Resolves the optional double-width font. An empty value retains
     /// CoreText's automatic fallback from the primary face.
     private func resolveWideFont(
         _ guifontwide: String, defaultSize: CGFloat
-    ) -> (CTFontDescriptor, CGFloat)? {
+    ) -> ResolvedGuifontEntry? {
         let fonts = parseGuifont(guifontwide, defaultSize: defaultSize)
-        for entry in fonts {
-            if let descriptor = FontManager.makeDescriptor(entry.name) {
-                return (descriptor, entry.size)
-            }
-        }
+        let installed = FontManager.makeResolvedGuifontEntries(fonts)
+        if let first = installed.first { return first }
         if !fonts.isEmpty {
             enqueue(.errorWriteln(
                 "Error: Invalid font(s): guifontwide=\(guifontwide)"))

--- a/Tests/RenderTests.swift
+++ b/Tests/RenderTests.swift
@@ -371,6 +371,120 @@ final class RenderTests: XCTestCase {
         XCTAssertEqual(CTFontGetSize(resized.font(.none, wide: true)), 30)
     }
 
+    func testFontFamilyPreservesFallbackCascadeThroughCacheAndResize() throws {
+        let manager = FontManager()
+        let entries = FontManager.makeResolvedGuifontEntries([
+            GuifontEntry(name: "Nvmm Missing Font", size: 12),
+            GuifontEntry(name: "Helvetica", size: 15),
+            GuifontEntry(name: "Apple Symbols", size: 14),
+            GuifontEntry(name: "Menlo", size: 13),
+        ])
+        XCTAssertEqual(entries.count, 3)
+
+        let symbols = try XCTUnwrap(
+            FontManager.makeDescriptor("Apple Symbols"))
+        let menlo = try XCTUnwrap(FontManager.makeDescriptor("Menlo"))
+        let family = manager.family(
+            resolvedEntries: entries, scaleFactor: 2)
+        let equivalent = manager.family(
+            resolvedEntries: entries, scaleFactor: 2)
+        let reversed = manager.family(
+            resolvedEntries: Array(entries.reversed()),
+            scaleFactor: 2)
+
+        XCTAssertTrue(family.regular === equivalent.regular)
+        XCTAssertFalse(family.regular === reversed.regular)
+
+        // These assertions check the size attribute stored on each cascade
+        // descriptor, not the size CoreText actually renders a substituted
+        // glyph at (see testCoreTextSelectsConfiguredFallbackForMissingCharacter,
+        // which shows CoreText ignores this attribute and always renders
+        // substitutions at the primary face's size).
+        let faces: [FontAttributes] = [.none, .bold, .italic, .boldItalic]
+        for face in faces {
+            let cascade = try fallbackDescriptors(of: family.font(face))
+            XCTAssertEqual(cascade.count, 2)
+            XCTAssertEqual(descriptorName(cascade[0]), descriptorName(symbols))
+            XCTAssertEqual(descriptorName(cascade[1]), descriptorName(menlo))
+            XCTAssertEqual(descriptorSize(cascade[0]), 28)
+            XCTAssertEqual(descriptorSize(cascade[1]), 26)
+        }
+
+        let resized = manager.resized(family, size: 17, scaleFactor: 2)
+        let cascade = try fallbackDescriptors(of: resized.regular)
+
+        XCTAssertEqual(resized.unscaledSize, 17)
+        XCTAssertEqual(descriptorSize(cascade[0]), 32)
+        XCTAssertEqual(descriptorSize(cascade[1]), 30)
+    }
+
+    func testFamilyReusingPreservesFallbackCascadeWithNewWideEntry() throws {
+        let manager = FontManager()
+        let symbols = try XCTUnwrap(FontManager.makeDescriptor("Apple Symbols"))
+        let entries = FontManager.makeResolvedGuifontEntries([
+            GuifontEntry(name: "Helvetica", size: 15),
+            GuifontEntry(name: "Apple Symbols", size: 14),
+        ])
+        let family = manager.family(resolvedEntries: entries, scaleFactor: 2)
+        let wideDescriptor = try XCTUnwrap(FontManager.makeDescriptor("Menlo"))
+        let wideEntry = ResolvedGuifontEntry(
+            descriptor: wideDescriptor, unscaledSize: 13)
+
+        let reused = manager.family(
+            reusing: family, wideEntry: wideEntry, scaleFactor: 2)
+        let faces: [FontAttributes] = [.none, .bold, .italic, .boldItalic]
+
+        for face in faces {
+            XCTAssertTrue(reused.font(face) === family.font(face))
+            let cascade = try fallbackDescriptors(of: reused.font(face))
+            XCTAssertEqual(descriptorName(cascade[0]), descriptorName(symbols))
+        }
+        XCTAssertFalse(
+            reused.font(.none, wide: true) === family.font(.none, wide: true))
+        XCTAssertEqual(CTFontGetSize(reused.font(.none, wide: true)), 26)
+        XCTAssertEqual(
+            CTFontCopyPostScriptName(reused.font(.none, wide: true)),
+            CTFontCopyPostScriptName(
+                CTFontCreateWithFontDescriptor(wideDescriptor, 26, nil)))
+    }
+
+    func testCoreTextSelectsConfiguredFallbackForMissingCharacter() throws {
+        let fixture = try requireFallbackFixture()
+        let family = FontManager().family(
+            resolvedEntries: [
+                ResolvedGuifontEntry(
+                    descriptor: fixture.primary, unscaledSize: 15),
+                ResolvedGuifontEntry(
+                    descriptor: fixture.fallback, unscaledSize: 14),
+            ],
+            scaleFactor: 2)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .init(kCTFontAttributeName as String): family.regular,
+        ]
+        let attributed = NSAttributedString(
+            string: fixture.text, attributes: attributes)
+        let line = CTLineCreateWithAttributedString(attributed)
+        let runs = try XCTUnwrap(CTLineGetGlyphRuns(line) as? [CTRun])
+        let run = try XCTUnwrap(runs.first)
+        let runAttributes = CTRunGetAttributes(run) as NSDictionary
+        let selectedValue = try XCTUnwrap(
+            runAttributes[kCTFontAttributeName])
+        let selected = selectedValue as! CTFont
+        // CoreText's cascade-list resolution picks the correct fallback
+        // face, but does not honor that entry's own size attribute at
+        // shape time: substituted glyphs always come back sized at the
+        // primary face's resolved size (15 * scaleFactor 2 = 30), not the
+        // fallback's own configured 14. This matches how other CoreText
+        // consumers with fallback (e.g. kitty) render substituted glyphs
+        // at the main face's size.
+        let fallback = CTFontCreateWithFontDescriptor(
+            fixture.fallback, 30, nil)
+
+        XCTAssertEqual(CTFontCopyPostScriptName(selected),
+                       CTFontCopyPostScriptName(fallback))
+        XCTAssertEqual(CTFontGetSize(selected), 30)
+    }
+
     func testLineSpaceChangesAndClampsCellHeight() {
         let manager = FontManager()
         let family = manager.family(
@@ -916,6 +1030,59 @@ final class RenderTests: XCTestCase {
         XCTAssertEqual(cached.rect.texture_origin, .zero)
         // Nothing was packed, so the atlas is untouched.
         XCTAssertTrue(context.glyphManager.maskTexture === before)
+    }
+
+    private func fallbackDescriptors(of font: CTFont) throws
+        -> [CTFontDescriptor] {
+        let descriptor = CTFontCopyFontDescriptor(font)
+        return try XCTUnwrap(CTFontDescriptorCopyAttribute(
+            descriptor, kCTFontCascadeListAttribute) as? [CTFontDescriptor])
+    }
+
+    private func descriptorName(_ descriptor: CTFontDescriptor) -> String? {
+        CTFontDescriptorCopyAttribute(
+            descriptor, kCTFontNameAttribute) as? String
+    }
+
+    private func descriptorSize(_ descriptor: CTFontDescriptor) -> CGFloat? {
+        let number = CTFontDescriptorCopyAttribute(
+            descriptor, kCTFontSizeAttribute) as? NSNumber
+        return number.map { CGFloat(truncating: $0) }
+    }
+
+    private func requireFallbackFixture() throws -> (
+        primary: CTFontDescriptor,
+        fallback: CTFontDescriptor,
+        text: String
+    ) {
+        let primary = try XCTUnwrap(FontManager.makeDescriptor("Helvetica"))
+        let fallback = try XCTUnwrap(
+            FontManager.makeDescriptor("Apple Symbols"))
+        let primaryFont = CTFontCreateWithFontDescriptor(primary, 28, nil)
+        let fallbackFont = CTFontCreateWithFontDescriptor(fallback, 28, nil)
+        let ranges: [ClosedRange<UInt32>] = [
+            0x2190...0x2BFF,
+            0xE000...0xF8FF,
+        ]
+
+        for range in ranges {
+            for value in range {
+                var character = UniChar(value)
+                var primaryGlyph = CGGlyph(0)
+                var fallbackGlyph = CGGlyph(0)
+                let primaryHasGlyph = CTFontGetGlyphsForCharacters(
+                    primaryFont, &character, &primaryGlyph, 1)
+                let fallbackHasGlyph = CTFontGetGlyphsForCharacters(
+                    fallbackFont, &character, &fallbackGlyph, 1)
+                if (!primaryHasGlyph || primaryGlyph == 0),
+                   fallbackHasGlyph, fallbackGlyph != 0,
+                   let scalar = Unicode.Scalar(value) {
+                    return (primary, fallback, String(scalar))
+                }
+            }
+        }
+        throw XCTSkip(
+            "No stable system-font character exercised explicit fallback")
     }
 
     /// Total ink in a rasterized bitmap.


### PR DESCRIPTION
## Summary

Attach every font listed after the first entry in `guifont` to the primary font's CoreText cascade list, so glyphs missing from the primary font (e.g. Nerd Font icons) render via the listed fallback instead of CoreText's `LastResort` box.

## Motivation

CoreText's own automatic font substitution doesn't search third-party installed fonts for Private Use Area codepoints (the range Nerd Font icons occupy) — it resolves them to `LastResort` even when a covering Nerd Font is installed system-wide. This is a documented CoreText limitation, not unique to Nvmm (Kitty hit the same thing on macOS and added a manual `symbol_map` workaround). Explicitly listing a fallback font in `guifont` and attaching it to a CoreText cascade list does resolve it correctly.

Example: `guifont=Triplicate T4c:h22,Symbols Nerd Font Mono:h22`.

Each fallback's own `:h<size>` is still parsed and stored, but CoreText does not honor a cascade entry's size at glyph-substitution time — a fallback face always renders at the primary face's resolved size, same as it does in kitty's fallback implementation. So today the per-fallback size mainly documents intent; it doesn't yet change rendering. A follow-up could add kitty-style shrink-to-fit for glyphs that overflow the cell.

Note: unlike vanilla Neovim's `:help guifont` (first installed font wins), Nvmm now treats every installed entry as an ordered CoreText fallback cascade — intentional, but not reflected in the bundled `:help` since that's vendored from upstream Neovim.

I considered matching Neovide's single trailing options-block syntax (`Primary,Fallback:h12:b`) but kept the existing per-font `:h<size>` suffix, since it matches goneovim's equivalent fallback feature and Vim's own historical per-font option syntax.

A natural follow-up (not included here) would be to auto-detect an installed Nerd Font at runtime — the way Ghostty/WezTerm/Neovide resolve icon fallbacks automatically — and feed it into this same cascade mechanism, so `guifont` wouldn't need to list a fallback explicitly at all. Shipping the explicit-list mechanism first, then layering auto-detection on top of it, seemed like the more reviewable order.

This touches a fairly central piece of the font pipeline (descriptor caching, cascade lists, wide-font resolution) — happy to adjust the approach or representation if you'd prefer something different.

## Screenshots

TODO

## Testing

- Added `FontManager` tests covering cascade ordering per face, cache reuse across resize, and CoreText's fallback selection (typeface and rendered size) for a character missing from the primary font.
- Restored the existing fast path for `guifontwide`-only changes (previously silently dropped by the refactor) via a new `family(reusing:wideEntry:scaleFactor:)`.
- Visually verified with `guifont=Triplicate T4c:h22,Symbols Nerd Font Mono:h22`.
