### PR TITLE
Fix: CLI environment forwarding

### DIFF
--- a/Nvmm/App/AppDelegate.swift
+++ b/Nvmm/App/AppDelegate.swift
@@ -339,7 +339,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if request.wait { controller.setCLIResponseChannel(channel) }
         controller.start(files: request.files,
                          directory: request.workingDirectory,
-                         arguments: request.arguments)
+                         arguments: request.arguments,
+                         environment: request.environment)
         Task {
             switch await controller.waitForStartup() {
             case .started:

--- a/Nvmm/App/CLIProtocol.swift
+++ b/Nvmm/App/CLIProtocol.swift
@@ -165,6 +165,9 @@ nonisolated struct CLIRequest: Codable, Sendable, Equatable {
     var workingDirectory: String
     var forceNewWindow: Bool
     var wait: Bool
+    // The helper's environment, applied to the new window's nvim. Optional:
+    // a request from an older helper has no key and still decodes.
+    var environment: [String: String]? = nil
 
     func validate() throws {
         guard version == CLIProtocol.version else {
@@ -174,6 +177,37 @@ nonisolated struct CLIRequest: Codable, Sendable, Equatable {
             throw CLIProtocolError.invalidWorkingDirectory
         }
         try CLIArguments.validateForwarded(arguments)
+        if let environment {
+            // A real environ cannot hold these shapes: `environ` splits each
+            // entry at the first `=`, and a C string cannot carry NUL.
+            for (key, value) in environment {
+                guard !key.isEmpty, !key.contains("="),
+                      !key.contains("\0"), !value.contains("\0") else {
+                    throw CLIProtocolError.invalidEnvironment
+                }
+            }
+        }
+    }
+
+    /// The request as one newline-terminated JSON line, at most
+    /// `maximumBytes` long. An oversized request drops its environment and
+    /// retries; a request that is still oversized throws.
+    func encodedLine(maximumBytes: Int) throws
+        -> (data: Data, droppedEnvironment: Bool) {
+        var data = try JSONEncoder().encode(self)
+        data.append(0x0a)
+        if data.count <= maximumBytes { return (data, false) }
+        guard environment != nil else {
+            throw CLIProtocolError.oversizedRequest
+        }
+        var trimmed = self
+        trimmed.environment = nil
+        var fallback = try JSONEncoder().encode(trimmed)
+        fallback.append(0x0a)
+        guard fallback.count <= maximumBytes else {
+            throw CLIProtocolError.oversizedRequest
+        }
+        return (fallback, true)
     }
 
     var needsNewWindow: Bool {
@@ -211,6 +245,8 @@ nonisolated enum CLIProtocolError: Error, Sendable, Equatable {
     case incompatibleVersion
     case invalidWorkingDirectory
     case invalidForwardedArguments
+    case invalidEnvironment
+    case oversizedRequest
 
     var message: String {
         switch self {
@@ -220,6 +256,10 @@ nonisolated enum CLIProtocolError: Error, Sendable, Equatable {
             "The working directory must be an absolute path."
         case .invalidForwardedArguments:
             "The request contains an unsupported Neovim argument."
+        case .invalidEnvironment:
+            "The request environment contains an invalid entry."
+        case .oversizedRequest:
+            "The request is too large."
         }
     }
 }

--- a/Nvmm/App/NeovimBundle.swift
+++ b/Nvmm/App/NeovimBundle.swift
@@ -34,17 +34,21 @@ enum NeovimBundle {
     /// The executable and argv to launch the embedded nvim with `arguments`
     /// (for example `["--embed"]`).
     ///
-    /// Launched from a terminal (`TERM` set) nvim is spawned directly,
-    /// inheriting the shell environment. Launched from the GUI — Finder,
-    /// Spotlight, the Dock, Xcode — there is no shell environment, so nvim is
-    /// exec'd from the user's login shell, which sources the login profile.
-    /// That gives nvim the same `PATH`, exports, and tools an interactive
-    /// shell has, so `init.lua` and anything it shells out to (LSP servers,
-    /// plugin managers, providers) behave as they do in a terminal.
+    /// `environment` is the environment the child will start from: a control
+    /// request's environment, or the app's own. With `TERM` set it comes
+    /// from a shell, its `PATH` is already correct, and nvim is spawned
+    /// directly — a login shell's profile could shadow that `PATH`. Without
+    /// `TERM` — Finder, Spotlight, the Dock, Xcode — there is no shell
+    /// environment, so nvim is exec'd from the user's login shell, which
+    /// sources the login profile. That gives nvim the same `PATH`, exports,
+    /// and tools an interactive shell has, so `init.lua` and anything it
+    /// shells out to (LSP servers, plugin managers, providers) behave as
+    /// they do in a terminal.
     nonisolated static func launchCommand(
-        nvimPath: String, arguments: [String]
+        nvimPath: String, arguments: [String],
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> (path: String, argv: [String]) {
-        if ProcessInfo.processInfo.environment["TERM"] != nil {
+        if environment["TERM"] != nil {
             return (nvimPath, [nvimPath] + arguments)
         }
         return loginShellCommand(shell: loginShell(),

--- a/Nvmm/RPC/NeovimProcess.swift
+++ b/Nvmm/RPC/NeovimProcess.swift
@@ -276,6 +276,7 @@ actor NeovimProcess {
     /// Spawns a Neovim process and connects to it over pipes.
     /// - Throws: `NeovimSpawnError` if a pipe or the process could not be created.
     func spawn(path: String, argv: [String], env: [String] = [],
+               baseEnvironment: [String: String]? = nil,
                workingDirectory: String? = nil) throws {
         guard state == .idle else {
             throw NeovimSpawnError(code: EISCONN, operation: "spawn")
@@ -306,6 +307,7 @@ actor NeovimProcess {
                                     output: read.pipe.writeEnd,
                                     error: standardError.pipe.writeEnd)
         let result = Spawn.spawn(path: path, argv: argv, env: env,
+                                 base: baseEnvironment,
                                  workingDirectory: workingDirectory,
                                  streams: streams)
 

--- a/Nvmm/RPC/Spawn.swift
+++ b/Nvmm/RPC/Spawn.swift
@@ -116,13 +116,16 @@ nonisolated enum Spawn {
 
     /// Spawns a child process executing `path`.
     ///
-    /// The child inherits the current process environment, extended by `env`
-    /// (each entry a `KEY=VALUE` string). When `workingDirectory` is non-nil
-    /// and non-empty the child changes into it before exec.
+    /// The child environment starts from `base` when one is given, and from
+    /// the current process environment when `base` is nil. The `env` entries
+    /// (each a `KEY=VALUE` string) then replace the values of the keys they
+    /// name. When `workingDirectory` is non-nil and non-empty the child
+    /// changes into it before exec.
     ///
     /// - Returns: A `Result`. When `error` is non-zero no process was created
     ///   and `pid` is undefined.
     static func spawn(path: String, argv: [String], env: [String],
+                      base: [String: String]? = nil,
                       workingDirectory: String?, streams: Streams) -> Result {
         var actions: posix_spawn_file_actions_t?
         posix_spawn_file_actions_init(&actions)
@@ -177,11 +180,12 @@ nonisolated enum Spawn {
             if code != 0 { return Result(pid: 0, error: code) }
         }
 
-        // Inherit the parent environment, with the caller's entries replacing
-        // the values of the keys they name. Appending them instead would leave
-        // both: a C `getenv` answers with the first of two entries for a key,
-        // which is the inherited one, so the caller's value would be ignored.
-        var environment = ProcessInfo.processInfo.environment
+        // Start from the base, or from the parent environment, with the
+        // caller's entries replacing the values of the keys they name.
+        // Appending them instead would leave both: a C `getenv` answers with
+        // the first of two entries for a key, which is the inherited one, so
+        // the caller's value would be ignored.
+        var environment = base ?? ProcessInfo.processInfo.environment
         for entry in env {
             guard let separator = entry.firstIndex(of: "=") else { continue }
             environment[String(entry[..<separator])] =

--- a/Nvmm/Window/WindowController.swift
+++ b/Nvmm/Window/WindowController.swift
@@ -291,6 +291,7 @@ final class WindowController: NSWindowController, NSWindowDelegate,
     private var startupFiles: [String] = []
     private var startupArguments: [String] = []
     private var startupDirectory: String?
+    private var startupEnvironment: [String: String]?
 
     /// How this window reaches Neovim: spawn an embedded process, or connect to
     /// one already running (a `:connect`/`:restart` handoff, or the "Connect to
@@ -389,11 +390,16 @@ final class WindowController: NSWindowController, NSWindowDelegate,
     /// `directory` is the working directory Neovim starts in; when nil it is
     /// derived from the first file, falling back to the invoking shell's
     /// working directory and then the home directory.
+    ///
+    /// `environment` is the complete environment Neovim starts with — a
+    /// control request carries the helper's — and nil keeps the app's own.
     func start(files: [String] = [], directory: String? = nil,
-               arguments: [String] = []) {
+               arguments: [String] = [],
+               environment: [String: String]? = nil) {
         startupFiles = files
         startupArguments = arguments
         startupDirectory = directory
+        startupEnvironment = environment
         source = .spawn
         launch()
     }
@@ -778,7 +784,8 @@ final class WindowController: NSWindowController, NSWindowDelegate,
     /// handed to the render task — carrying the spawn arguments resolved here
     /// so the task need not touch the main actor to build them.
     private enum LaunchPlan: Sendable {
-        case spawn(path: String, argv: [String], directory: String)
+        case spawn(path: String, argv: [String], directory: String,
+                   environment: [String: String]?)
         case connect(address: String)
     }
 
@@ -798,10 +805,13 @@ final class WindowController: NSWindowController, NSWindowDelegate,
                 handleDisconnect()
                 return
             }
-            let launch = NeovimBundle.launchCommand(nvimPath: nvimPath,
-                                                    arguments: neovimArguments())
+            let launch = NeovimBundle.launchCommand(
+                nvimPath: nvimPath, arguments: neovimArguments(),
+                environment: startupEnvironment
+                    ?? ProcessInfo.processInfo.environment)
             plan = .spawn(path: launch.path, argv: launch.argv,
-                          directory: workingDirectory())
+                          directory: workingDirectory(),
+                          environment: startupEnvironment)
         case .remote(let address):
             plan = .connect(address: address)
         }
@@ -861,8 +871,14 @@ final class WindowController: NSWindowController, NSWindowDelegate,
         renderTask = Task { [weak self] in
             do {
                 switch plan {
-                case .spawn(let path, let argv, let directory):
+                case .spawn(let path, let argv, let directory,
+                            let environment):
+                    // PWD must name the real working directory. The
+                    // inherited value names the directory of the app's
+                    // first launch.
                     try await process.spawn(path: path, argv: argv,
+                                            env: ["PWD=\(directory)"],
+                                            baseEnvironment: environment,
                                             workingDirectory: directory)
                 case .connect(let address):
                     try await process.connect(address)

--- a/Tests/CLIProtocolTests.swift
+++ b/Tests/CLIProtocolTests.swift
@@ -108,6 +108,75 @@ final class CLIProtocolTests: XCTestCase {
         }
     }
 
+    func testRequestCarriesAndValidatesEnvironment() throws {
+        var request = CLIRequest(
+            arguments: [], files: [], workingDirectory: "/tmp",
+            forceNewWindow: false, wait: false)
+        request.environment = ["PATH": "/usr/bin", "EMPTY": ""]
+        try request.validate()
+
+        let data = try JSONEncoder().encode(request)
+        let decoded = try JSONDecoder().decode(CLIRequest.self, from: data)
+        XCTAssertEqual(decoded, request)
+    }
+
+    // A request from an older helper has no environment key. It must still
+    // decode and validate, so the field cannot be required.
+    func testRequestWithoutEnvironmentKeyStillDecodes() throws {
+        let json = """
+        {"version": 1, "arguments": [], "files": [],
+         "workingDirectory": "/tmp", "forceNewWindow": false, "wait": false}
+        """
+        let decoded = try JSONDecoder().decode(CLIRequest.self,
+                                               from: Data(json.utf8))
+        XCTAssertNil(decoded.environment)
+        try decoded.validate()
+    }
+
+    // A real environ cannot hold these shapes, so a request that does was
+    // not built by the helper.
+    func testRequestRejectsMalformedEnvironmentEntries() {
+        let bad: [[String: String]] = [
+            ["": "value"], ["A=B": "value"],
+            ["A\0B": "value"], ["KEY": "a\0b"],
+        ]
+        for environment in bad {
+            var request = CLIRequest(
+                arguments: [], files: [], workingDirectory: "/tmp",
+                forceNewWindow: false, wait: false)
+            request.environment = environment
+            XCTAssertThrowsError(try request.validate()) { error in
+                XCTAssertEqual(error as? CLIProtocolError, .invalidEnvironment)
+            }
+        }
+    }
+
+    func testEncodedLineDropsOnlyAnOversizedEnvironment() throws {
+        var request = CLIRequest(
+            arguments: [], files: [], workingDirectory: "/tmp",
+            forceNewWindow: false, wait: false)
+        request.environment = ["KEY": "value"]
+
+        let kept = try request.encodedLine(
+            maximumBytes: CLIProtocol.maximumRequestBytes)
+        XCTAssertFalse(kept.droppedEnvironment)
+        XCTAssertEqual(kept.data.last, 0x0a)
+
+        request.environment = ["BIG": String(repeating: "x", count: 512)]
+        let dropped = try request.encodedLine(maximumBytes: 256)
+        XCTAssertTrue(dropped.droppedEnvironment)
+        let decoded = try JSONDecoder().decode(
+            CLIRequest.self, from: dropped.data.dropLast())
+        XCTAssertNil(decoded.environment)
+
+        request.environment = nil
+        request.files = [String(repeating: "y", count: 512)]
+        XCTAssertThrowsError(
+            try request.encodedLine(maximumBytes: 256)) { error in
+            XCTAssertEqual(error as? CLIProtocolError, .oversizedRequest)
+        }
+    }
+
     func testFileResolutionIsLexicalAndAllowsMissingPaths() {
         let request = CLIRequest(arguments: [], files: ["a/../new", "/x/../y"],
                                  workingDirectory: "/tmp/project",

--- a/Tests/NeovimBundleTests.swift
+++ b/Tests/NeovimBundleTests.swift
@@ -78,6 +78,27 @@ final class NeovimBundleTests: XCTestCase {
         XCTAssertEqual(arguments, ["--embed"])
     }
 
+    // A child environment with TERM comes from a terminal. Its PATH is
+    // already correct, and a login shell's profile could shadow it.
+    func testLaunchCommandWithTERMSpawnsNvimDirectly() {
+        let command = NeovimBundle.launchCommand(
+            nvimPath: "/opt/x/nvim", arguments: ["--embed"],
+            environment: ["TERM": "xterm-256color"])
+        XCTAssertEqual(command.path, "/opt/x/nvim")
+        XCTAssertEqual(command.argv, ["/opt/x/nvim", "--embed"])
+    }
+
+    func testLaunchCommandWithoutTERMUsesALoginShell() {
+        let command = NeovimBundle.launchCommand(
+            nvimPath: "/opt/x/nvim", arguments: ["--embed"],
+            environment: [:])
+        XCTAssertNotEqual(command.path, "/opt/x/nvim")
+        XCTAssertEqual(command.argv.count, 3)
+        XCTAssertTrue(command.argv[0].hasPrefix("-"))
+        XCTAssertEqual(command.argv[1], "-c")
+        XCTAssertTrue(command.argv[2].contains("'/opt/x/nvim'"))
+    }
+
     func testLoginShellCommandExecsNvimAsLoginShell() {
         let command = NeovimBundle.loginShellCommand(
             shell: "/bin/zsh", nvimPath: "/Apps/Nvmm.app/Contents/MacOS/nvim",

--- a/Tests/SpawnTests.swift
+++ b/Tests/SpawnTests.swift
@@ -119,6 +119,39 @@ final class SpawnTests: XCTestCase {
         XCTAssertEqual(entries, ["\(key)=\(replacement)"])
     }
 
+    /// A base environment replaces the parent environment completely, and an
+    /// `env` entry still overrides the base.
+    func testBaseEnvironmentReplacesTheParentEnvironment() async throws {
+        // HOME is exported by the parent; its absence from the child proves
+        // the base replaced the parent environment rather than merged in.
+        XCTAssertNotNil(ProcessInfo.processInfo.environment["HOME"])
+        let output = Spawn.openPipe()
+        XCTAssertEqual(output.error, 0)
+        defer { close(output.pipe.readEnd) }
+        let result = Spawn.spawn(
+            path: "/usr/bin/env", argv: ["/usr/bin/env"],
+            env: ["OVERRIDE=b"],
+            base: ["ONLY": "a", "OVERRIDE": "a"],
+            workingDirectory: nil,
+            streams: Spawn.Streams(output: output.pipe.writeEnd))
+        close(output.pipe.writeEnd)
+        XCTAssertEqual(result.error, 0)
+
+        var reported = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = read(output.pipe.readEnd, &buffer, buffer.count)
+            if count <= 0 { break }
+            reported.append(contentsOf: buffer[0..<count])
+        }
+        let termination = await Spawn.wait(forChild: result.pid)
+        XCTAssertEqual(termination, .exited(status: 0))
+
+        let entries = Set(String(decoding: reported, as: UTF8.self)
+            .split(separator: "\n").map(String.init))
+        XCTAssertEqual(entries, ["ONLY=a", "OVERRIDE=b"])
+    }
+
     func testParsesUnixAndTCPServerAddresses() {
         XCTAssertEqual(parseRPCAddress("/tmp/nvim.sock"),
                        .unix(path: "/tmp/nvim.sock"))

--- a/Tools/nvmm/NvmmCLI.swift
+++ b/Tools/nvmm/NvmmCLI.swift
@@ -46,12 +46,14 @@ private struct CLIClient {
     }
 
     func send(_ request: CLIRequest) throws {
-        var data = try JSONEncoder().encode(request)
-        data.append(0x0a)
-        guard data.count <= CLIProtocol.maximumRequestBytes else {
-            throw CLIError("Request is too large.")
+        let encoded = try request.encodedLine(
+            maximumBytes: CLIProtocol.maximumRequestBytes)
+        if encoded.droppedEnvironment {
+            FileHandle.standardError.write(Data(
+                "nvmm: The environment is too large and was not sent.\n"
+                    .utf8))
         }
-        try data.withUnsafeBytes { bytes in
+        try encoded.data.withUnsafeBytes { bytes in
             var offset = 0
             while offset < bytes.count {
                 let count = Darwin.write(descriptor,
@@ -117,10 +119,11 @@ private struct NvmmCLI {
                 return
             }
             let directory = try workingDirectory()
-            let request = CLIRequest(
+            var request = CLIRequest(
                 arguments: parsed.arguments, files: parsed.files,
                 workingDirectory: directory,
                 forceNewWindow: parsed.forceNewWindow, wait: parsed.wait)
+            request.environment = ProcessInfo.processInfo.environment
             try request.validate()
             try CLIEndpoint.prepareDirectory()
 


### PR DESCRIPTION
Note that I am not a Swift dev, so if any of this is not idiomatic, please let me know. It's all been generated by Claude, but I did review it and I believe it to be solid.

Fixes #4 

## Problem

The app captures its environment once, at launch, and every window spawns nvim from that copy. `nvmm -N` from a second terminal opens a new window, but that window's nvim still gets the first terminal's `PATH` and version-manager
variables. LSP servers in the new window then resolve the wrong `node`.

Two windows in different projects therefore cannot use different node versions. The spawned nvim's `PWD` variable is also stale: it names the directory of the app's first launch, not the window's real working directory.

## Change

The `nvmm` helper now sends its complete environment in the control request, and the app spawns that request's window from it:

- `CLIRequest` gains an optional `environment` dictionary. `validate()` rejects entries a real environ cannot hold. A new
  `encodedLine(maximumBytes:)` drops an oversized environment and keeps the rest of the request; the helper then prints a note to stderr.
- `Spawn.spawn` accepts a base environment. When one is given, the child starts from it — a full replacement, not a merge, so no stale key from the app environment survives. The `env:` override entries still apply on top.
- `WindowController` stores the request environment and hands it to the spawn. Every spawn now also sets `PWD` to the real working directory.
- `NeovimBundle.launchCommand` reads `TERM` from the environment the child will start from. A request environment from a terminal has `TERM`, so nvim spawns directly and no login-shell profile can shadow its `PATH`.

## Compatibility

- No protocol version bump. The field is optional: a request from an older helper still decodes and behaves as before.
- Menu-opened windows (File → New Window, Finder, Open Recent) keep the app environment, as before.
- A request that opens files into an existing window cannot change that nvim's environment; this is unchanged.
- The environment crosses only the user-private control socket (mode `0700`, ownership checked), so no new trust boundary appears.

## Testing

- New unit tests: request round-trip and validation, the missing-key decode, the oversize fallback, base-environment replacement in `Spawn`, and the `TERM` decision in `launchCommand`. Full suite passes.
- End-to-end on macOS: launched the app with a bare marker environment, then ran the helper from 2 synthetic environments in different directories. Each window's nvim held exactly its own request environment — its `PATH`, its marker variable, and a `PWD` equal to its real working directory — and the app-launched window kept the old login-shell behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)